### PR TITLE
Updated LICENSE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This project leverages machine learning techniques to predict **Rice Yield (Kg/h
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [MIT License](LICENSE.md).
 
 
 


### PR DESCRIPTION
Issue #31 – Fix LICENSE Link

Title: Fix broken LICENSE link in README

Description:
I, @vinitjain2005, have fixed the LICENSE link in the README file, which was previously not working.
Now the link correctly points to the MIT License file.

Contributor: @vinitjain2005

Screenshot:
<img width="900" height="225" alt="Screenshot 2025-10-03 201720" src="https://github.com/user-attachments/assets/35dfe2a8-9de0-4ed2-bfe9-e700ae9a810f" />
